### PR TITLE
Add JWT-based token authentication service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,17 +29,43 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.12.5</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/com/sharifrahim/jwt_auth/config/AuthProperties.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/config/AuthProperties.java
@@ -1,0 +1,15 @@
+package com.sharifrahim.jwt_auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "auth")
+public class AuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String secretKey;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/ApiController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/ApiController.java
@@ -1,0 +1,25 @@
+package com.sharifrahim.jwt_auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sharifrahim.jwt_auth.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ApiController {
+    private final TokenService tokenService;
+
+    @GetMapping("/data")
+    public ResponseEntity<String> protectedEndpoint(@RequestHeader("Authorization") String auth) {
+        String token = auth.replace("Bearer ", "");
+        tokenService.validateAccessToken(token);
+        return ResponseEntity.ok("secured data");
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.sharifrahim.jwt_auth.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import io.jsonwebtoken.JwtException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<String> handleJwt(JwtException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
@@ -1,0 +1,36 @@
+package com.sharifrahim.jwt_auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sharifrahim.jwt_auth.model.dto.TokenRefreshRequest;
+import com.sharifrahim.jwt_auth.model.dto.TokenRequest;
+import com.sharifrahim.jwt_auth.model.dto.TokenResponse;
+import com.sharifrahim.jwt_auth.service.TokenService;
+import com.sharifrahim.jwt_auth.service.TokenService.TokenPair;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    @PostMapping
+    public ResponseEntity<TokenResponse> token(@RequestBody TokenRequest request) {
+        TokenPair pair = tokenService.createTokens(request.getClientId(), request.getClientSecret());
+        return ResponseEntity.ok(new TokenResponse(pair.accessToken().getValue(), pair.refreshToken().getValue(),
+                pair.accessToken().getExpiry().getEpochSecond()));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
+        TokenPair pair = tokenService.refreshTokens(request.getRefreshToken());
+        return ResponseEntity.ok(new TokenResponse(pair.accessToken().getValue(), pair.refreshToken().getValue(),
+                pair.accessToken().getExpiry().getEpochSecond()));
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.sharifrahim.jwt_auth.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/exception/TokenRefreshException.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/exception/TokenRefreshException.java
@@ -1,0 +1,7 @@
+package com.sharifrahim.jwt_auth.exception;
+
+public class TokenRefreshException extends RuntimeException {
+    public TokenRefreshException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/model/BlacklistedToken.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/model/BlacklistedToken.java
@@ -1,0 +1,20 @@
+package com.sharifrahim.jwt_auth.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlacklistedToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String tokenHash;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/model/Token.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/model/Token.java
@@ -1,0 +1,13 @@
+package com.sharifrahim.jwt_auth.model;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Token {
+    private String value;
+    private Instant expiry;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.sharifrahim.jwt_auth.model.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenRequest.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenRequest.java
@@ -1,0 +1,9 @@
+package com.sharifrahim.jwt_auth.model.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenRequest {
+    private String clientId;
+    private String clientSecret;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenResponse.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/model/dto/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.sharifrahim.jwt_auth.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private long expiresIn;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,12 @@
+package com.sharifrahim.jwt_auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sharifrahim.jwt_auth.model.BlacklistedToken;
+
+import java.util.Optional;
+
+public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
+    Optional<BlacklistedToken> findByTokenHash(String tokenHash);
+    boolean existsByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/AccessToken.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/AccessToken.java
@@ -1,0 +1,25 @@
+package com.sharifrahim.jwt_auth.service;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sharifrahim.jwt_auth.model.Token;
+import com.sharifrahim.jwt_auth.util.JWTUtil;
+
+@Component
+@RequiredArgsConstructor
+public class AccessToken implements TokenGenerator {
+    private final JWTUtil jwtUtil;
+    private final long expirationSeconds = 600; // 10 minutes
+
+    @Override
+    public Token generate(String subject) {
+        Instant expiry = Instant.now().plusSeconds(expirationSeconds);
+        String token = jwtUtil.sign(subject, expiry, Map.of("type", "access"));
+        return new Token(token, expiry);
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/BlacklistService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/BlacklistService.java
@@ -1,0 +1,44 @@
+package com.sharifrahim.jwt_auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sharifrahim.jwt_auth.model.BlacklistedToken;
+import com.sharifrahim.jwt_auth.repository.BlacklistedTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BlacklistService {
+    private final BlacklistedTokenRepository repository;
+
+    public boolean isBlacklisted(String token) {
+        return repository.existsByTokenHash(hash(token));
+    }
+
+    @Transactional
+    public void blacklist(String token) {
+        if (!isBlacklisted(token)) {
+            repository.save(new BlacklistedToken(null, hash(token)));
+        }
+    }
+
+    private String hash(String token) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(token.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/RefreshToken.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.sharifrahim.jwt_auth.service;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sharifrahim.jwt_auth.model.Token;
+import com.sharifrahim.jwt_auth.util.JWTUtil;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshToken implements TokenGenerator {
+    private final JWTUtil jwtUtil;
+    private final long expirationSeconds = 3600; // 1 hour
+
+    @Override
+    public Token generate(String subject) {
+        Instant expiry = Instant.now().plusSeconds(expirationSeconds);
+        String token = jwtUtil.sign(subject, expiry, Map.of("type", "refresh"));
+        return new Token(token, expiry);
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/TokenGenerator.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/TokenGenerator.java
@@ -1,0 +1,7 @@
+package com.sharifrahim.jwt_auth.service;
+
+import com.sharifrahim.jwt_auth.model.Token;
+
+public interface TokenGenerator {
+    Token generate(String subject);
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
@@ -1,0 +1,66 @@
+package com.sharifrahim.jwt_auth.service;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+
+import com.sharifrahim.jwt_auth.config.AuthProperties;
+import com.sharifrahim.jwt_auth.model.Token;
+import com.sharifrahim.jwt_auth.service.AccessToken;
+import com.sharifrahim.jwt_auth.service.RefreshToken;
+import com.sharifrahim.jwt_auth.util.JWTUtil;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final AccessToken accessTokenGenerator;
+    private final RefreshToken refreshTokenGenerator;
+    private final JWTUtil jwtUtil;
+    private final BlacklistService blacklistService;
+    private final AuthProperties authProperties;
+
+    public TokenPair createTokens(String clientId, String clientSecret) {
+        authenticate(clientId, clientSecret);
+        Token access = accessTokenGenerator.generate(clientId);
+        Token refresh = refreshTokenGenerator.generate(clientId);
+        return new TokenPair(access, refresh);
+    }
+
+    public Claims validateAccessToken(String token) {
+        if (blacklistService.isBlacklisted(token)) {
+            throw new JwtException("Token blacklisted");
+        }
+        Claims claims = jwtUtil.validate(token);
+        if (!"access".equals(claims.get("type"))) {
+            throw new JwtException("Invalid access token");
+        }
+        return claims;
+    }
+
+    public TokenPair refreshTokens(String refreshToken) {
+        if (blacklistService.isBlacklisted(refreshToken)) {
+            throw new JwtException("Token blacklisted");
+        }
+        Claims claims = jwtUtil.validate(refreshToken);
+        if (!"refresh".equals(claims.get("type"))) {
+            throw new JwtException("Not a refresh token");
+        }
+        String subject = claims.getSubject();
+        blacklistService.blacklist(refreshToken);
+        Token newAccess = accessTokenGenerator.generate(subject);
+        Token newRefresh = refreshTokenGenerator.generate(subject);
+        return new TokenPair(newAccess, newRefresh);
+    }
+
+    private void authenticate(String clientId, String clientSecret) {
+        if (!authProperties.getClientId().equals(clientId) || !authProperties.getClientSecret().equals(clientSecret)) {
+            throw new JwtException("Invalid client credentials");
+        }
+    }
+
+    public record TokenPair(Token accessToken, Token refreshToken) {}
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
@@ -1,0 +1,43 @@
+package com.sharifrahim.jwt_auth.util;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+public class EncryptionUtil {
+    public static KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static byte[] encrypt(byte[] data, String secret) {
+        try {
+            SecretKey key = new SecretKeySpec(secret.getBytes(), "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+            return cipher.doFinal(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static byte[] decrypt(byte[] data, String secret) {
+        try {
+            SecretKey key = new SecretKeySpec(secret.getBytes(), "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.DECRYPT_MODE, key);
+            return cipher.doFinal(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/util/JWTUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/JWTUtil.java
@@ -1,0 +1,51 @@
+package com.sharifrahim.jwt_auth.util;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JWTUtil {
+    private final KeyPair keyPair;
+
+    public JWTUtil() {
+        this.keyPair = EncryptionUtil.generateKeyPair();
+    }
+
+    public String sign(String subject, Instant expiry, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .addClaims(claims)
+                .setExpiration(Date.from(expiry))
+                .setIssuedAt(new Date())
+                .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
+                .compact();
+    }
+
+    public Claims validate(String token) {
+        return Jwts.parser()
+                .verifyWith(keyPair.getPublic())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public PublicKey getPublicKey() {
+        return keyPair.getPublic();
+    }
+
+    public PrivateKey getPrivateKey() {
+        return keyPair.getPrivate();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,13 +3,18 @@ spring:
     name: jwt-auth
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/demo_auth
-    username: postgres
-    password: password
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:authdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.H2Dialect
+
+auth:
+  client-id: demo
+  client-secret: secret
+  secret-key: changemechangeme

--- a/src/test/java/com/sharifrahim/jwt_auth/service/TokenServiceTest.java
+++ b/src/test/java/com/sharifrahim/jwt_auth/service/TokenServiceTest.java
@@ -1,0 +1,35 @@
+package com.sharifrahim.jwt_auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.sharifrahim.jwt_auth.config.AuthProperties;
+
+import io.jsonwebtoken.Claims;
+
+@SpringBootTest
+class TokenServiceTest {
+
+    @Autowired
+    TokenService tokenService;
+    @Autowired
+    AuthProperties authProperties;
+
+    @Test
+    void createAndValidate() {
+        TokenService.TokenPair pair = tokenService.createTokens(authProperties.getClientId(), authProperties.getClientSecret());
+        Claims claims = tokenService.validateAccessToken(pair.accessToken().getValue());
+        assertThat(claims.getSubject()).isEqualTo(authProperties.getClientId());
+    }
+
+    @Test
+    void refresh() {
+        TokenService.TokenPair pair = tokenService.createTokens(authProperties.getClientId(), authProperties.getClientSecret());
+        TokenService.TokenPair refreshed = tokenService.refreshTokens(pair.refreshToken().getValue());
+        assertThat(tokenService.validateAccessToken(refreshed.accessToken().getValue()).getSubject())
+                .isEqualTo(authProperties.getClientId());
+    }
+}

--- a/src/test/java/com/sharifrahim/jwt_auth/util/JWTUtilTest.java
+++ b/src/test/java/com/sharifrahim/jwt_auth/util/JWTUtilTest.java
@@ -1,0 +1,21 @@
+package com.sharifrahim.jwt_auth.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.jsonwebtoken.Claims;
+
+class JWTUtilTest {
+    JWTUtil util = new JWTUtil();
+
+    @Test
+    void signAndValidate() {
+        String token = util.sign("user", Instant.now().plusSeconds(60), Map.of("type", "access"));
+        Claims claims = util.validate(token);
+        assertThat(claims.getSubject()).isEqualTo("user");
+    }
+}


### PR DESCRIPTION
## Summary
- implement token generators and JWT utility
- add token service with refresh and blacklist logic
- expose `/token` and `/api` endpoints
- manage RSA key generation and AES encryption utilities
- integrate Spring Boot with H2 database
- provide unit tests for token service and JWT util

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6859d68b08908323aef10e92e5a4fb07