### PR TITLE
Add AES Encryption Utility

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
@@ -1,0 +1,57 @@
+package com.sharifrahim.jwt_auth.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Component
+public class EncryptionUtil {
+
+    private final SecretKeySpec secretKey;
+    private final IvParameterSpec ivParameterSpec;
+
+    public EncryptionUtil(@Value("${encryption.secret-key}") String key,
+                          @Value("${encryption.salt}") String salt) {
+        try {
+            byte[] keyBytes = Arrays.copyOf(MessageDigest.getInstance("SHA-256")
+                    .digest(key.getBytes(StandardCharsets.UTF_8)), 16);
+            this.secretKey = new SecretKeySpec(keyBytes, "AES");
+
+            byte[] ivBytes = Arrays.copyOf(MessageDigest.getInstance("SHA-256")
+                    .digest(salt.getBytes(StandardCharsets.UTF_8)), 16);
+            this.ivParameterSpec = new IvParameterSpec(ivBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unable to initialize EncryptionUtil", e);
+        }
+    }
+
+    public String encrypt(String input) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParameterSpec);
+            byte[] encrypted = cipher.doFinal(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new RuntimeException("Error encrypting data", e);
+        }
+    }
+
+    public String decrypt(String encrypted) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec);
+            byte[] decoded = Base64.getDecoder().decode(encrypted);
+            return new String(cipher.doFinal(decoded), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Error decrypting data", e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,3 +13,7 @@ spring:
       ddl-auto: none
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+encryption:
+  secret-key: changeit12345678
+  salt: example-salt

--- a/src/test/java/com/sharifrahim/jwt_auth/EncryptionUtilTests.java
+++ b/src/test/java/com/sharifrahim/jwt_auth/EncryptionUtilTests.java
@@ -1,0 +1,23 @@
+package com.sharifrahim.jwt_auth;
+
+import com.sharifrahim.jwt_auth.util.EncryptionUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class EncryptionUtilTests {
+
+    @Autowired
+    private EncryptionUtil encryptionUtil;
+
+    @Test
+    void encryptAndDecrypt() {
+        String original = "hello";
+        String encrypted = encryptionUtil.encrypt(original);
+        String decrypted = encryptionUtil.decrypt(encrypted);
+        assertEquals(original, decrypted);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EncryptionUtil` for basic AES encryption/decryption
- store secret key and salt in `application.yaml`
- add unit test for the new utility

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6859f9512d6483239840df1ace3eeaa4