### PR TITLE
Use Lombok for API client model

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/config/JpaConfig.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.sharifrahim.jwt_auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of("system");
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/entity/ApiClient.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/entity/ApiClient.java
@@ -1,0 +1,27 @@
+package com.sharifrahim.jwt_auth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "api_client")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApiClient extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "client_id", nullable = false)
+    private String clientId;
+
+    @Column(name = "client_secret_enc", nullable = false)
+    private String clientSecretEnc;
+
+    @Column(name = "private_key_enc", nullable = false)
+    private String privateKeyEnc;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/entity/Auditable.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/entity/Auditable.java
@@ -1,0 +1,37 @@
+package com.sharifrahim.jwt_auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class Auditable {
+
+    @CreatedBy
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @LastModifiedBy
+    @Column(name = "modify_by")
+    private String modifyBy;
+
+    @LastModifiedDate
+    @Column(name = "modify_date")
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
@@ -1,0 +1,9 @@
+package com.sharifrahim.jwt_auth.repository;
+
+import com.sharifrahim.jwt_auth.entity.ApiClient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApiClientRepository extends JpaRepository<ApiClient, Long> {
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/ApiClientService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/ApiClientService.java
@@ -1,0 +1,15 @@
+package com.sharifrahim.jwt_auth.service;
+
+import com.sharifrahim.jwt_auth.entity.ApiClient;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApiClientService {
+
+    ApiClient save(ApiClient client);
+
+    Optional<ApiClient> findById(Long id);
+
+    List<ApiClient> findAll();
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
@@ -1,0 +1,40 @@
+package com.sharifrahim.jwt_auth.service.impl;
+
+import com.sharifrahim.jwt_auth.entity.ApiClient;
+import com.sharifrahim.jwt_auth.repository.ApiClientRepository;
+import com.sharifrahim.jwt_auth.service.ApiClientService;
+import com.sharifrahim.jwt_auth.util.EncryptionUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ApiClientServiceImpl implements ApiClientService {
+
+    private final ApiClientRepository repository;
+    private final EncryptionUtil encryptionUtil;
+
+    @Override
+    public ApiClient save(ApiClient client) {
+        client.setClientSecretEnc(encryptionUtil.encrypt(client.getClientSecretEnc()));
+        client.setPrivateKeyEnc(encryptionUtil.encrypt(client.getPrivateKeyEnc()));
+        return repository.save(client);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ApiClient> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ApiClient> findAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,9 @@ spring:
       ddl-auto: none
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  sql:
+    init:
+      mode: always
 
 encryption:
   secret-key: changeit12345678

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS api_client (
+    id SERIAL PRIMARY KEY,
+    client_id VARCHAR(255) NOT NULL,
+    client_secret_enc TEXT NOT NULL,
+    private_key_enc TEXT NOT NULL,
+    created_by VARCHAR(100),
+    created_date TIMESTAMP,
+    modify_by VARCHAR(100),
+    modify_date TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- replace manual getters/setters with Lombok annotations in `ApiClient` and `Auditable`
- use Lombok `@RequiredArgsConstructor` in the service implementation
- run database schema on each start and use `CREATE TABLE IF NOT EXISTS`

## Testing
- `mvn test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685a099f1c9c83238fe5dcacb26d23fa