### PR TITLE
Add RSA keypair generation

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
@@ -7,6 +7,8 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -52,6 +54,16 @@ public class EncryptionUtil {
             return new String(cipher.doFinal(decoded), StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new RuntimeException("Error decrypting data", e);
+        }
+    }
+
+    public KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unable to generate RSA key pair", e);
         }
     }
 }

--- a/src/test/java/com/sharifrahim/jwt_auth/EncryptionUtilTests.java
+++ b/src/test/java/com/sharifrahim/jwt_auth/EncryptionUtilTests.java
@@ -1,6 +1,8 @@
 package com.sharifrahim.jwt_auth;
 
 import com.sharifrahim.jwt_auth.util.EncryptionUtil;
+import java.security.KeyPair;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,5 +21,12 @@ class EncryptionUtilTests {
         String encrypted = encryptionUtil.encrypt(original);
         String decrypted = encryptionUtil.decrypt(encrypted);
         assertEquals(original, decrypted);
+    }
+
+    @Test
+    void generateKeyPair() {
+        KeyPair keyPair = encryptionUtil.generateKeyPair();
+        assertNotNull(keyPair.getPrivate());
+        assertNotNull(keyPair.getPublic());
     }
 }


### PR DESCRIPTION
## Summary
- extend `EncryptionUtil` with method to generate RSA key pair
- test key pair generation in `EncryptionUtilTests`

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_685a354a65ac83238649a60b6138f982