### PR TITLE
Add JwtUtil for JWT creation and validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -45,12 +45,17 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.auth0</groupId>
+                        <artifactId>java-jwt</artifactId>
+                        <version>4.4.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/sharifrahim/jwt_auth/util/JwtUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/JwtUtil.java
@@ -1,0 +1,32 @@
+package com.sharifrahim.jwt_auth.util;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.stereotype.Component;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    public String generateToken(String subject, Duration validity, RSAPrivateKey privateKey) {
+        Algorithm algorithm = Algorithm.RSA256(null, privateKey);
+        long nowMillis = System.currentTimeMillis();
+        return JWT.create()
+                .withSubject(subject)
+                .withIssuedAt(new Date(nowMillis))
+                .withExpiresAt(new Date(nowMillis + validity.toMillis()))
+                .sign(algorithm);
+    }
+
+    public DecodedJWT validateToken(String token, RSAPublicKey publicKey) {
+        Algorithm algorithm = Algorithm.RSA256(publicKey, null);
+        JWTVerifier verifier = JWT.require(algorithm).build();
+        return verifier.verify(token);
+    }
+}

--- a/src/test/java/com/sharifrahim/jwt_auth/JwtUtilTests.java
+++ b/src/test/java/com/sharifrahim/jwt_auth/JwtUtilTests.java
@@ -1,0 +1,31 @@
+package com.sharifrahim.jwt_auth;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.sharifrahim.jwt_auth.util.EncryptionUtil;
+import com.sharifrahim.jwt_auth.util.JwtUtil;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class JwtUtilTests {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private EncryptionUtil encryptionUtil;
+
+    @Test
+    void generateAndValidate() {
+        KeyPair pair = encryptionUtil.generateKeyPair();
+        String token = jwtUtil.generateToken("bob", Duration.ofMinutes(5), (RSAPrivateKey) pair.getPrivate());
+        DecodedJWT decoded = jwtUtil.validateToken(token, (RSAPublicKey) pair.getPublic());
+        assertEquals("bob", decoded.getSubject());
+    }
+}


### PR DESCRIPTION
## Summary
- add `java-jwt` dependency
- implement `JwtUtil` component for RSA-based JWT generation and validation
- test JWT utility

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_685a379e0ee08323a64d692cb96aee25