### PR TITLE
Add token service and DTOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
                         <artifactId>spring-boot-starter-data-jpa</artifactId>
                 </dependency>
 
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
@@ -1,0 +1,25 @@
+package com.sharifrahim.jwt_auth.controller;
+
+import com.sharifrahim.jwt_auth.dto.TokenRequestDto;
+import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
+import com.sharifrahim.jwt_auth.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/token")
+    public ResponseEntity<TokenResponseDto> createToken(@RequestBody TokenRequestDto request) {
+        return tokenService.createToken(request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/TokenRequestDto.java
@@ -1,0 +1,9 @@
+package com.sharifrahim.jwt_auth.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenRequestDto {
+    private String clientId;
+    private String clientSecret;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.sharifrahim.jwt_auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
@@ -4,6 +4,10 @@ import com.sharifrahim.jwt_auth.entity.ApiClient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ApiClientRepository extends JpaRepository<ApiClient, Long> {
+
+    Optional<ApiClient> findByClientId(String clientId);
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/service/ApiClientService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/ApiClientService.java
@@ -11,5 +11,7 @@ public interface ApiClientService {
 
     Optional<ApiClient> findById(Long id);
 
+    Optional<ApiClient> findByClientId(String clientId);
+
     List<ApiClient> findAll();
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
@@ -1,0 +1,10 @@
+package com.sharifrahim.jwt_auth.service;
+
+import com.sharifrahim.jwt_auth.dto.TokenRequestDto;
+import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
+
+import java.util.Optional;
+
+public interface TokenService {
+    Optional<TokenResponseDto> createToken(TokenRequestDto request);
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
@@ -34,6 +34,12 @@ public class ApiClientServiceImpl implements ApiClientService {
 
     @Override
     @Transactional(readOnly = true)
+    public Optional<ApiClient> findByClientId(String clientId) {
+        return repository.findByClientId(clientId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<ApiClient> findAll() {
         return repository.findAll();
     }

--- a/src/main/java/com/sharifrahim/jwt_auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/impl/TokenServiceImpl.java
@@ -1,0 +1,73 @@
+package com.sharifrahim.jwt_auth.service.impl;
+
+import com.sharifrahim.jwt_auth.dto.TokenRequestDto;
+import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
+import com.sharifrahim.jwt_auth.entity.ApiClient;
+import com.sharifrahim.jwt_auth.service.ApiClientService;
+import com.sharifrahim.jwt_auth.service.TokenService;
+import com.sharifrahim.jwt_auth.util.EncryptionUtil;
+import com.sharifrahim.jwt_auth.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+
+    private final ApiClientService apiClientService;
+    private final EncryptionUtil encryptionUtil;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    @Transactional
+    public Optional<TokenResponseDto> createToken(TokenRequestDto request) {
+        return apiClientService.findByClientId(request.getClientId())
+                .filter(c -> clientSecretMatches(c, request.getClientSecret()))
+                .map(c -> generateTokensForClient(c, request.getClientSecret()));
+    }
+
+    private boolean clientSecretMatches(ApiClient client, String clientSecret) {
+        String decrypted = encryptionUtil.decrypt(client.getClientSecretEnc());
+        return decrypted.equals(clientSecret);
+    }
+
+    private TokenResponseDto generateTokensForClient(ApiClient client, String clientSecret) {
+        RSAPrivateKey key = ensurePrivateKey(client, clientSecret);
+        String accessToken = jwtUtil.generateToken(client.getClientId(), Duration.ofHours(1), key);
+        String refreshToken = jwtUtil.generateToken(client.getClientId(), Duration.ofDays(7), key);
+        return new TokenResponseDto(accessToken, refreshToken);
+    }
+
+    private RSAPrivateKey ensurePrivateKey(ApiClient client, String clientSecret) {
+        String privateKeyPlain = encryptionUtil.decrypt(client.getPrivateKeyEnc());
+        if (privateKeyPlain == null || privateKeyPlain.isBlank()) {
+            KeyPair pair = encryptionUtil.generateKeyPair();
+            RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) pair.getPrivate();
+            privateKeyPlain = Base64.getEncoder().encodeToString(rsaPrivateKey.getEncoded());
+            client.setPrivateKeyEnc(privateKeyPlain);
+            client.setClientSecretEnc(clientSecret);
+            apiClientService.save(client);
+        }
+        return toPrivateKey(privateKeyPlain);
+    }
+
+    private RSAPrivateKey toPrivateKey(String key) {
+        try {
+            byte[] bytes = Base64.getDecoder().decode(key);
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(bytes);
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPrivateKey) factory.generatePrivate(spec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid private key", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- simplify TokenController by delegating token logic to a new service
- create TokenService interface and implementation
- generate access/refresh tokens via TokenServiceImpl
- add DTOs for token request and response

## Testing
- `mvn -q test` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685a3b2405348323a571fb1e9b84239a