### PR TITLE
Implement refresh token endpoint

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
@@ -2,6 +2,7 @@ package com.sharifrahim.jwt_auth.controller;
 
 import com.sharifrahim.jwt_auth.dto.TokenRequestDto;
 import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
+import com.sharifrahim.jwt_auth.dto.RefreshTokenRequestDto;
 import com.sharifrahim.jwt_auth.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,13 @@ public class TokenController {
     @PostMapping("/token")
     public ResponseEntity<TokenResponseDto> createToken(@RequestBody TokenRequestDto request) {
         return tokenService.createToken(request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<TokenResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto request) {
+        return tokenService.refreshToken(request.getRefreshToken())
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
     }

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,8 @@
+package com.sharifrahim.jwt_auth.dto;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface TokenService {
     Optional<TokenResponseDto> createToken(TokenRequestDto request);
+
+    Optional<TokenResponseDto> refreshToken(String refreshToken);
 }


### PR DESCRIPTION
## Summary
- allow refreshing JWT tokens via `/token/refresh`
- add RefreshTokenRequestDto
- expose `refreshToken` method in `TokenService`
- implement token validation and generation logic in `TokenServiceImpl`

## Testing
- `mvn -q -DskipTests=false test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685a455a52348323a8d443dfc89cabd6