### PR TITLE
Add ApiResponse wrapper

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
@@ -3,6 +3,8 @@ package com.sharifrahim.jwt_auth.controller;
 import com.sharifrahim.jwt_auth.dto.TokenRequestDto;
 import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
 import com.sharifrahim.jwt_auth.dto.RefreshTokenRequestDto;
+import com.sharifrahim.jwt_auth.dto.ApiResponse;
+import com.sharifrahim.jwt_auth.dto.ResponseStatus;
 import com.sharifrahim.jwt_auth.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,16 +20,18 @@ public class TokenController {
     private final TokenService tokenService;
 
     @PostMapping("/token")
-    public ResponseEntity<TokenResponseDto> createToken(@RequestBody TokenRequestDto request) {
+    public ResponseEntity<ApiResponse<TokenResponseDto>> createToken(@RequestBody TokenRequestDto request) {
         return tokenService.createToken(request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+                .map(token -> ResponseEntity.ok(ApiResponse.of(ResponseStatus.SUCCESS, token)))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(ApiResponse.of(ResponseStatus.UNAUTHORIZED, null)));
     }
 
     @PostMapping("/token/refresh")
-    public ResponseEntity<TokenResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto request) {
+    public ResponseEntity<ApiResponse<TokenResponseDto>> refreshToken(@RequestBody RefreshTokenRequestDto request) {
         return tokenService.refreshToken(request.getRefreshToken())
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+                .map(token -> ResponseEntity.ok(ApiResponse.of(ResponseStatus.SUCCESS, token)))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(ApiResponse.of(ResponseStatus.UNAUTHORIZED, null)));
     }
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/ApiResponse.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.sharifrahim.jwt_auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private int statusCode;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> of(ResponseStatus status, T data) {
+        return new ApiResponse<>(status.getStatus().value(), status.getMessage(), data);
+    }
+}

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/ResponseStatus.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/ResponseStatus.java
@@ -1,0 +1,24 @@
+package com.sharifrahim.jwt_auth.dto;
+
+import org.springframework.http.HttpStatus;
+
+public enum ResponseStatus {
+    SUCCESS(HttpStatus.OK, "Success"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ResponseStatus(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## Summary
- wrap controller responses in ApiResponse
- define ResponseStatus enum for standard response codes and messages

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_685a4b64441883238609b47591d5352f