### PR TITLE
Update TokenFilter to set authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
                         <artifactId>java-jwt</artifactId>
                         <version>4.4.0</version>
                 </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-core</artifactId>
+                </dependency>
         </dependencies>
 
 	<build>

--- a/src/main/java/com/sharifrahim/jwt_auth/filter/TokenFilter.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/filter/TokenFilter.java
@@ -1,13 +1,18 @@
 package com.sharifrahim.jwt_auth.filter;
 
 import com.sharifrahim.jwt_auth.service.TokenService;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 
@@ -30,6 +35,10 @@ public class TokenFilter extends OncePerRequestFilter {
             String token = header.substring(7);
             try {
                 tokenService.validateToken(token);
+                DecodedJWT decoded = JWT.decode(token);
+                String username = decoded.getClaim("username").asString();
+                Authentication auth = new UsernamePasswordAuthenticationToken(username, null, java.util.Collections.emptyList());
+                SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (Exception e) {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
                 return;


### PR DESCRIPTION
## Summary
- add spring-security-core for Authentication classes
- store authenticated user details in `SecurityContextHolder`

## Testing
- `./mvnw -q test`

------
https://chatgpt.com/codex/tasks/task_e_685a55206b288323800a26460d182ac1