### PR TITLE
Add extensive javadocs and logging

### DIFF
--- a/src/main/java/com/sharifrahim/jwt_auth/JwtAuthApplication.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/JwtAuthApplication.java
@@ -3,6 +3,12 @@ package com.sharifrahim.jwt_auth;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Entry point for the JWT authentication service application.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @SpringBootApplication
 public class JwtAuthApplication {
 

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TestController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TestController.java
@@ -3,18 +3,28 @@ package com.sharifrahim.jwt_auth.controller;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Simple controller exposing secured and public endpoints for testing.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @RestController
+@Slf4j
 public class TestController {
 
     @GetMapping("/secure/test")
     public String test(Authentication authentication) {
         String username = authentication != null ? authentication.getName() : "anonymous";
+        log.debug("Secure endpoint accessed by {}", username);
         return "user " + username + " successfully reached endpoint";
     }
 
     @GetMapping("/test")
     public String publicTest() {
+        log.debug("Public test endpoint called");
         return "public test endpoint";
     }
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/controller/TokenController.java
@@ -7,28 +7,44 @@ import com.sharifrahim.jwt_auth.dto.ApiResponse;
 import com.sharifrahim.jwt_auth.dto.ResponseStatus;
 import com.sharifrahim.jwt_auth.service.TokenService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST endpoints for obtaining and refreshing JWT tokens.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @RequiredArgsConstructor
 @RestController
+@Slf4j
 public class TokenController {
 
     private final TokenService tokenService;
 
+    /**
+     * Create new JWT access and refresh tokens for the given client credentials.
+     */
     @PostMapping("/token")
     public ResponseEntity<ApiResponse<TokenResponseDto>> createToken(@RequestBody TokenRequestDto request) {
+        log.debug("Token request for clientId={}", request.getClientId());
         return tokenService.createToken(request)
                 .map(token -> ResponseEntity.ok(ApiResponse.of(ResponseStatus.SUCCESS, token)))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(ApiResponse.of(ResponseStatus.UNAUTHORIZED, null)));
     }
 
+    /**
+     * Refresh an access token using an existing refresh token.
+     */
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse<TokenResponseDto>> refreshToken(@RequestBody RefreshTokenRequestDto request) {
+        log.debug("Refresh token request");
         return tokenService.refreshToken(request.getRefreshToken())
                 .map(token -> ResponseEntity.ok(ApiResponse.of(ResponseStatus.SUCCESS, token)))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/ApiResponse.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/ApiResponse.java
@@ -3,6 +3,12 @@ package com.sharifrahim.jwt_auth.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * Wrapper for API responses used by the service.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Data
 @AllArgsConstructor
 public class ApiResponse<T> {

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/RefreshTokenRequestDto.java
@@ -2,6 +2,9 @@ package com.sharifrahim.jwt_auth.dto;
 
 import lombok.Data;
 
+/**
+ * Request body containing a refresh token for re-issuing access tokens.
+ */
 @Data
 public class RefreshTokenRequestDto {
     private String refreshToken;

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/ResponseStatus.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/ResponseStatus.java
@@ -2,6 +2,12 @@ package com.sharifrahim.jwt_auth.dto;
 
 import org.springframework.http.HttpStatus;
 
+/**
+ * Enumeration of API response statuses returned to clients.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 public enum ResponseStatus {
     SUCCESS(HttpStatus.OK, "Success"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized");

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/TokenRequestDto.java
@@ -2,6 +2,9 @@ package com.sharifrahim.jwt_auth.dto;
 
 import lombok.Data;
 
+/**
+ * Request body for obtaining a new JWT token.
+ */
 @Data
 public class TokenRequestDto {
     private String clientId;

--- a/src/main/java/com/sharifrahim/jwt_auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/dto/TokenResponseDto.java
@@ -3,6 +3,9 @@ package com.sharifrahim.jwt_auth.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * DTO returned to clients after successful token generation.
+ */
 @Data
 @AllArgsConstructor
 public class TokenResponseDto {

--- a/src/main/java/com/sharifrahim/jwt_auth/entity/ApiClient.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/entity/ApiClient.java
@@ -5,6 +5,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Entity representing an API client that can request JWT tokens.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Entity
 @Table(name = "api_client")
 @Getter

--- a/src/main/java/com/sharifrahim/jwt_auth/filter/TokenFilter.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/filter/TokenFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,8 +17,15 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * Servlet filter that validates JWT tokens on secured endpoints.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class TokenFilter extends OncePerRequestFilter {
 
     private final TokenService tokenService;
@@ -34,12 +42,14 @@ public class TokenFilter extends OncePerRequestFilter {
             }
             String token = header.substring(7);
             try {
+                log.debug("Validating token for request to {}", path);
                 tokenService.validateToken(token);
                 DecodedJWT decoded = JWT.decode(token);
                 String username = decoded.getClaim("username").asString();
                 Authentication auth = new UsernamePasswordAuthenticationToken(username, null, java.util.Collections.emptyList());
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (Exception e) {
+                log.warn("Invalid token: {}", e.getMessage());
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
                 return;
             }

--- a/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/repository/ApiClientRepository.java
@@ -6,6 +6,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+/**
+ * JPA repository for {@link ApiClient} entities.
+ */
 @Repository
 public interface ApiClientRepository extends JpaRepository<ApiClient, Long> {
 

--- a/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/TokenService.java
@@ -5,10 +5,25 @@ import com.sharifrahim.jwt_auth.dto.TokenResponseDto;
 
 import java.util.Optional;
 
+/**
+ * Service abstraction for issuing and validating JWT tokens.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 public interface TokenService {
+    /**
+     * Create a pair of access and refresh tokens for the specified client.
+     */
     Optional<TokenResponseDto> createToken(TokenRequestDto request);
 
+    /**
+     * Refresh an access token using the provided refresh token.
+     */
     Optional<TokenResponseDto> refreshToken(String refreshToken);
 
+    /**
+     * Validate the authenticity and expiration of a JWT token.
+     */
     void validateToken(String token);
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/service/impl/ApiClientServiceImpl.java
@@ -5,15 +5,23 @@ import com.sharifrahim.jwt_auth.repository.ApiClientRepository;
 import com.sharifrahim.jwt_auth.service.ApiClientService;
 import com.sharifrahim.jwt_auth.util.EncryptionUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Service for CRUD operations on {@link ApiClient} entities.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class ApiClientServiceImpl implements ApiClientService {
 
     private final ApiClientRepository repository;
@@ -21,6 +29,7 @@ public class ApiClientServiceImpl implements ApiClientService {
 
     @Override
     public ApiClient save(ApiClient client) {
+        log.debug("Saving ApiClient with clientId={}", client.getClientId());
         client.setClientSecretEnc(encryptionUtil.encrypt(client.getClientSecretEnc()));
         client.setPrivateKeyEnc(encryptionUtil.encrypt(client.getPrivateKeyEnc()));
         return repository.save(client);
@@ -29,18 +38,21 @@ public class ApiClientServiceImpl implements ApiClientService {
     @Override
     @Transactional(readOnly = true)
     public Optional<ApiClient> findById(Long id) {
+        log.debug("Finding ApiClient by id={}", id);
         return repository.findById(id);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Optional<ApiClient> findByClientId(String clientId) {
+        log.debug("Finding ApiClient by clientId={}", clientId);
         return repository.findByClientId(clientId);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<ApiClient> findAll() {
+        log.debug("Retrieving all ApiClients");
         return repository.findAll();
     }
 }

--- a/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/EncryptionUtil.java
@@ -2,6 +2,7 @@ package com.sharifrahim.jwt_auth.util;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -14,7 +15,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 
+/**
+ * Utility class for symmetric encryption and RSA key generation.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Component
+@Slf4j
 public class EncryptionUtil {
 
     private final SecretKeySpec secretKey;
@@ -31,6 +39,7 @@ public class EncryptionUtil {
                     .digest(salt.getBytes(StandardCharsets.UTF_8)), 16);
             this.ivParameterSpec = new IvParameterSpec(ivBytes);
         } catch (NoSuchAlgorithmException e) {
+            log.error("Unable to initialize EncryptionUtil", e);
             throw new IllegalStateException("Unable to initialize EncryptionUtil", e);
         }
     }
@@ -42,6 +51,7 @@ public class EncryptionUtil {
             byte[] encrypted = cipher.doFinal(input.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(encrypted);
         } catch (Exception e) {
+            log.error("Error encrypting data", e);
             throw new RuntimeException("Error encrypting data", e);
         }
     }
@@ -53,6 +63,7 @@ public class EncryptionUtil {
             byte[] decoded = Base64.getDecoder().decode(encrypted);
             return new String(cipher.doFinal(decoded), StandardCharsets.UTF_8);
         } catch (Exception e) {
+            log.error("Error decrypting data", e);
             throw new RuntimeException("Error decrypting data", e);
         }
     }
@@ -63,6 +74,7 @@ public class EncryptionUtil {
             generator.initialize(2048);
             return generator.generateKeyPair();
         } catch (NoSuchAlgorithmException e) {
+            log.error("Unable to generate RSA key pair", e);
             throw new IllegalStateException("Unable to generate RSA key pair", e);
         }
     }

--- a/src/main/java/com/sharifrahim/jwt_auth/util/JwtUtil.java
+++ b/src/main/java/com/sharifrahim/jwt_auth/util/JwtUtil.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -12,7 +13,14 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
 
+/**
+ * Helper methods for generating and validating JWT tokens.
+ *
+ * Author: sharif rahim
+ * <a href="https://github.com/sharifrahim">https://github.com/sharifrahim</a>
+ */
 @Component
+@Slf4j
 public class JwtUtil {
 
     public String generateToken(String subject, Duration validity, RSAPrivateKey privateKey) {
@@ -29,12 +37,16 @@ public class JwtUtil {
         if (claims != null) {
             claims.forEach(builder::withClaim);
         }
-        return builder.sign(algorithm);
+        String token = builder.sign(algorithm);
+        log.debug("Generated token for subject {}", subject);
+        return token;
     }
 
     public DecodedJWT validateToken(String token, RSAPublicKey publicKey) {
         Algorithm algorithm = Algorithm.RSA256(publicKey, null);
         JWTVerifier verifier = JWT.require(algorithm).build();
-        return verifier.verify(token);
+        DecodedJWT decoded = verifier.verify(token);
+        log.debug("Validated token for subject {}", decoded.getSubject());
+        return decoded;
     }
 }


### PR DESCRIPTION
## Summary
- add author information and javadocs across service classes and DTOs
- include @Slf4j logging in services, controllers, filter and utils
- document repository and entities for clarity

## Testing
- `mvn -q test` *(failed: could not verify build success)*

------
https://chatgpt.com/codex/tasks/task_e_685a61d54b688323874e781d55ff5c55